### PR TITLE
Surface type

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PROJECT_SOURCES
 	matrixExponential.cpp 
 	ODEintegrator.cpp 
 	cellConnection.cpp
+	surface.cpp
 )	
 
 # All sources that also need to be tested in unit tests go into a static library

--- a/src/meshCellData.cpp
+++ b/src/meshCellData.cpp
@@ -47,6 +47,16 @@ meshCell::meshCell(int iIndex, int jIndex, int absoluteIndex, double xCor,
 void meshCell::addSpecies(double molarMass, double initCon, double diffCoeff){
 
 	species spec(molarMass, initCon, diffCoeff);
+	// loop over connections to see if the species needs to be added
+	// to a surface
+	for (int conCount = 0; conCount < connections.size(); conCount ++){
+		connection* thisCon = getConnection(conCount);
+		// if the pointer is not null then add species to that surface
+		if(thisCon->connectionFacePtr->surfacePtr){
+			thisCon->connectionFacePtr->surfacePtr->addSpecies(molarMass, 
+				initCon, diffCoeff);
+		}
+	}
 	speciesVector.push_back(spec);
 
 }
@@ -101,7 +111,7 @@ void meshCell::setTemperature(double temp){
 //*****************************************************************************
 // Gets a pointer to a cell connection
 //
-// @param specID	ID of the connection
+// @param conID		ID of the connection
 //								north = 0
 //								south = 1
 //								east = 2
@@ -110,8 +120,23 @@ void meshCell::setTemperature(double temp){
 connection* meshCell::getConnection(int conID){
 	// Checks to make sure the conID is not out of range
 	assert(conID <= connections.size() and conID>= 0);
-	//assert(connections[conID].loc == conID);
+	assert(connections[conID].loc == conID);
 	return &connections[conID];
+}
+
+//*****************************************************************************
+// Adds a surface to the cell
+//
+// @param locID			location ID of the surface to add
+//								north = 0
+//								south = 1
+//								east = 2
+//								west = 3
+//	@param surfacePtr		Pointer to the surface object
+//*****************************************************************************
+void meshCell::addSurface(int locID, surface* surfacePtr_){
+	connection* myCon = getConnection(locID);
+	myCon->connectionFacePtr->surfacePtr = surfacePtr_;
 }
 
 //*****************************************************************************

--- a/src/meshCellData.h
+++ b/src/meshCellData.h
@@ -8,6 +8,7 @@
 #define MESHCELLDATA_H
 #include "cellConnection.h"
 #include "meshCellFace.h"
+#include "surface.h"
 #include "species.h"
 #include <vector>
 #include <assert.h>
@@ -64,6 +65,8 @@ class meshCell {
 	void setPressure(double);
 	// Gets a pointer to the connection
 	connection* getConnection(int);
+	// Adds a surface 
+	void addSurface(int, surface*);
 	// Clean species
 	void cleanSpecies();
 

--- a/src/meshCellFace.h
+++ b/src/meshCellFace.h
@@ -12,6 +12,7 @@
 //*****************************************************************************
 #ifndef MESHCELLFACE_H
 #define MESHCELLFACE_H
+#include "surface.h"
 
 class meshCellFace {
 
@@ -27,7 +28,8 @@ class meshCellFace {
 	double dx = 0.0;
 	// y direction length
 	double dy = 0.0;
-	
+	// pointer to the surface object. This is a physical surface
+	surface* surfacePtr = nullptr;
 
 	// Constructor
 	meshCellFace(int, int, int);

--- a/src/modelMesh.cpp
+++ b/src/modelMesh.cpp
@@ -326,6 +326,87 @@ void modelMesh::setCellPressure(int i, int j, double pressure){
 }
 
 //*****************************************************************************
+// Adds a surface to a cell
+//
+// @param i				x cell index
+// @param j				y cell index
+// @param loc			Location of the surface in the cell
+//							north
+//							south
+//							east
+//							west
+//*****************************************************************************
+void modelMesh::addSurface(int i, int j, std::string loc){
+	int locID = -1;
+	if (loc == "north"){locID = 0;};
+	if (loc == "south"){locID = 1;};
+	if (loc == "east"){locID = 2;};
+	if (loc == "west"){locID = 3;};
+	assert(locID != -1);
+
+	meshCell* cell = getCellByLoc(i,j);
+	surface mySurface = surface();
+	cell->addSurface(locID, &mySurface);
+	surfaces.push_back(mySurface);
+}
+
+//*****************************************************************************
+// Adds a surface to the mesh boundary
+//
+// @param loc			Location of the surface boundary
+//							north
+//							south
+//							east
+//							west
+//*****************************************************************************
+void modelMesh::addBoundarySurface(std::string loc){
+	int xCellMax = numOfxCells - 1;
+	int xCellMin = 0;
+	int yCellMax = numOfyCells - 1;
+	int yCellMin = 0;
+	int locID = -1;
+
+	if (loc == "north"){locID = 0;};
+	if (loc == "south"){locID = 1;};
+	if (loc == "east"){locID = 2;};
+	if (loc == "west"){locID = 3;};
+	assert(locID != -1);
+
+	switch(locID){
+
+		// North location
+		case 0: {
+			for (int i = 0; i < numOfxCells; i++){
+				addSurface(i, yCellMax, "north");
+			}
+			break;
+		}
+		// South location
+		case 1: {
+			for (int i = 0; i < numOfxCells; i++){
+				addSurface(i, yCellMin, "south");
+			}
+			break;
+		}
+		// East location
+		case 2: {
+			for (int j = 0; j < numOfyCells; j++){
+				addSurface(xCellMax, j, "east");
+			}
+			break;
+		}
+		// West location
+		case 3: {
+			for (int j = 0; j < numOfyCells; j++){
+				addSurface(xCellMin, j, "west");
+			}
+			break;
+		}
+	}
+
+}
+
+//*****************************************************************************
 // Cleans the model
 //*****************************************************************************
 void modelMesh::clean(){

--- a/src/modelMesh.h
+++ b/src/modelMesh.h
@@ -7,6 +7,7 @@
 #define MODELMESH_H
 #include "meshCellData.h"
 #include "meshCellFace.h"
+#include "surface.h"
 #include <vector>
 #include <assert.h>
 
@@ -27,6 +28,8 @@ class modelMesh {
 	std::vector<meshCell> meshCells;
 	// Vector of all cell faces
 	std::vector<meshCellFace> meshCellFaces;
+	// Vector of cell surfaces
+	std::vector<surface> surfaces;
 	// Change in x direction
 	double dx = 0.0;
 	// Change in y direction
@@ -57,6 +60,10 @@ class modelMesh {
 	void setCellTemperature(int, int, double);
 	// Set pressure in a cell
 	void setCellPressure(int, int, double);
+	// Adds a physical surface to a cell
+	void addSurface(int, int, std::string);
+	// Adds a physical surface along a boundary
+	void addBoundarySurface(std::string);
 	// Cleans the model
 	void clean();
 

--- a/src/speciesDriver.cpp
+++ b/src/speciesDriver.cpp
@@ -124,10 +124,6 @@ void speciesDriver::setSpeciesSource(int i, int j, int specID, std::vector<doubl
 void speciesDriver::setBoundaryCondition(std::string BCType, std::string loc, 
 	int specID, double bc){
 
-	int xCellMax = modelPtr->numOfxCells - 1;
-	int xCellMin = 0;
-	int yCellMax = modelPtr->numOfyCells - 1;
-	int yCellMin = 0;
 	int locID = -1;
 	dummySpec = 1;
 

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -37,3 +37,4 @@ species* surface::getSpecies(int specID){
 //*****************************************************************************
 void surface::clean(){
 	speciesVector.clear();
+}

--- a/src/surface.h
+++ b/src/surface.h
@@ -7,6 +7,7 @@
 #ifndef SURFACE_H
 #define SURFACE_H
 #include "species.h"
+#include <assert.h>
 
 class surface {
 
@@ -18,7 +19,8 @@ class surface {
 	// Gets a pointer to the species
 	species* getSpecies(int);
 	// Clean
-	clean();
+	void clean();
+
 	private:
 	// Vector of the species on the surface
 	std::vector<species> speciesVector;


### PR DESCRIPTION
Adds a physical surface type to the meshcell face object. This surface object holds a vector of species much like the mesh cell data. The mesh surfaces must be defined before the species driver starts adding species